### PR TITLE
fix: hyphenated parameters in headers/queries and spaces in tag names

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -377,7 +377,8 @@ const getPathVirtualProperty = (
       ) {
         const _schema = current.schema;
         const item: IDefinitionVirtualProperty = {
-          name: current.name,
+          name: camelCase(current.name),
+          originalName: current.name,
           type: current.type ?? _schema?.type ?? "",
           required: current.required,
           description: current.description,

--- a/src/plugins/action.ts
+++ b/src/plugins/action.ts
@@ -216,6 +216,7 @@ const parseParams = (parameters: IPathVirtualParameter, action: string) =>
       if (!_multiParam) {
         _formalParam = {
           name: item.name,
+          originalName: item.originalName,
           category: current,
           type: _type,
           description: (item.title || item.description) ?? "",
@@ -366,7 +367,7 @@ const getActionFiles = (data: Map<string, IPathVirtualProperty>) => {
 
   Logs.info(`${getT("$t(plugin.parserAction)")}...`);
   data.forEach((item, key) => {
-    const _tag = item.tag;
+    const _tag = item.tag?.replace(/\s+/g, "");
 
     if (!_tag) {
       Logs.error(getT("$t(plugin.no_tag)", { url: item.url }));

--- a/src/plugins/dart/template/actionMethod.eta
+++ b/src/plugins/dart/template/actionMethod.eta
@@ -26,7 +26,7 @@ Future<<%~ it.responseType %>> <%= it.methodName %>(<% it.params.forEach((param,
       method: '<%= it.method %>'<% if (it.params.length) { %>,
       params: {
 <% it.params.forEach((param, index) => { %>
-        '<%= param.category %>': <% if (param.category === param.name) { %><%= param.name %><% } else { %>{'<%= param.name %>' : <%= param.name %>}<% } %><% if (index < it.params.length - 1) { %>, <% } %>
+        '<%= param.category %>': <% if (param.category === param.name) { %><%= param.name %><% } else { %>{'<%= param.originalName || param.name %>' : <%= param.name %>}<% } %><% if (index < it.params.length - 1) { %>, <% } %>
 
 <% }) %>
       }

--- a/src/plugins/dart/template/definitionFooter.eta
+++ b/src/plugins/dart/template/definitionFooter.eta
@@ -8,7 +8,7 @@
   factory <%= it.defName %>.fromJson(Map<String, dynamic> json) {
     return <%= it.defName %>(
 <% it.props.forEach((prop, index) => { %>
-      <%= prop.name %>: json['<%= prop.name %>']<% if (index < it.props.length - 1) { %>,<% } %>
+      <%= prop.name %>: json['<%= prop.originalName || prop.name %>']<% if (index < it.props.length - 1) { %>,<% } %>
 
 <% }) %>
     );
@@ -18,7 +18,7 @@
     final Map<String, dynamic> data = <String, dynamic>{};
 
 <% it.props.forEach((prop) => { %>
-    data['<%= prop.name %>'] = <%= prop.name %>;
+    data['<%= prop.originalName || prop.name %>'] = <%= prop.name %>;
 <% }) %>
 
     return data;

--- a/src/plugins/swift/template/actionMethod.eta
+++ b/src/plugins/swift/template/actionMethod.eta
@@ -24,7 +24,7 @@ public func <%= it.methodName %>(<% it.params.forEach((param, index) => { %>
     <% if (pathParams.length > 0) { %>
     let pathParams: [String: String] = [
         <% pathParams.forEach((param, index) => { %>
-        "<%= param.name %>": String(<%= param.name %>)<% if (index < pathParams.length - 1) { %>,<% } %>
+        "<%= param.originalName || param.name %>": String(<%= param.name %>)<% if (index < pathParams.length - 1) { %>,<% } %>
         <% }) %>
     ]
     let parsedUrl = "<%= it.url %>".parsePathParams(pathParams)

--- a/src/plugins/swift/template/definitionFooter.eta
+++ b/src/plugins/swift/template/definitionFooter.eta
@@ -1,1 +1,8 @@
+<% if (it.props && it.props.some(prop => prop.originalName && prop.originalName !== prop.name)) { %>
+    private enum CodingKeys: String, CodingKey {
+<% it.props.forEach(prop => { %>
+        case <%= prop.name %> = "<%= prop.originalName || prop.name %>"
+<% }) %>
+    }
+<% } %>
 }

--- a/src/plugins/typescript/template/actionMethod.eta
+++ b/src/plugins/typescript/template/actionMethod.eta
@@ -35,7 +35,7 @@ export const <%= it.methodName %> = (<% it.params.forEach((param, index) => { %>
 <% it.params.forEach((param, index) => { %>
   <%= param.category %><% if (param.category === param.name) { %>
 <% } else { %>: <% if (param.category === 'body') { %><%= param.name %><% } else { %>{
-		<%= param.name %>
+		<%= param.originalName ? "'" + param.originalName + "': " + param.name : param.name %>
 
 	}<% } %>
 <% } %><% if (index < it.params.length - 1) { %>, <% } %>

--- a/src/plugins/typescript/template/definitionBody.eta
+++ b/src/plugins/typescript/template/definitionBody.eta
@@ -4,4 +4,4 @@
 
    */
 <% } %>
-  <%= it.prop.name %><% if (!it.prop.required) { %>?<% } %>: <%~ it.propType %><% if (it.nullable) { %> | <%~ it.nullable %><% } %>;
+  "<%= it.prop.originalName || it.prop.name %>"<% if (!it.prop.required) { %>?<% } %>: <%~ it.propType %><% if (it.nullable) { %> | <%~ it.nullable %><% } %>;

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -172,6 +172,7 @@ export interface IDefinitionVirtualProperty {
    * 属性名
    */
   name: string;
+  originalName?: string;
   /**
    * 属性类型。数组的情况，通常是 action 的返回值会多个
    */


### PR DESCRIPTION
This PR fixes two critical bugs: 1. Header/Query parameter keys containing hyphens now properly map to camelCase variable names while preserving original names in serialization. 2. OpenAPI tags with spaces are sanitized to prevent invalid filenames.